### PR TITLE
Support interactive and piped input for calculator CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Kalkulačka
+
+Tento repozitář obsahuje jednoduchou kalkulačku v Pythonu. Výrazy jsou
+vyhodnocovány bezpečně pomocí modulu `ast` a kromě základních operací je možné
+využít i funkce `abs` a `round`.
+
+## Požadavky
+
+* Python 3.11 (nebo novější verze řady 3.x)
+
+## Spuštění z příkazové řádky
+
+```bash
+python -m calculator "2 + 3 * 4"
+```
+
+Výsledek je vypsán na standardní výstup. Pomocí přepínače `--decimals` lze
+nechat výsledek zaokrouhlit na zadaný počet desetinných míst:
+
+```bash
+python -m calculator "10 / 3" --decimals 2
+```
+
+Bez uvedení výrazu se kalkulačka spustí v interaktivním režimu, ve kterém
+zpracovává výrazy po jednotlivých řádcích. Režim je možné vyvolat i explicitně
+pomocí přepínače `--interactive`.
+
+```bash
+python -m calculator --interactive
+```
+
+Výraz je možné předat také přes standardní vstup, například při použití roury:
+
+```bash
+echo "(5 + 3) * 2" | python -m calculator
+```
+
+## Použití v Pythonu
+
+```python
+from calculator import Calculator
+
+calc = Calculator()
+print(calc.evaluate("(5 + 3) ** 2"))
+```
+
+## Testy
+
+Testy spustíte příkazem:
+
+```bash
+pytest
+```

--- a/calculator/__init__.py
+++ b/calculator/__init__.py
@@ -1,0 +1,229 @@
+"""Simple expression-based calculator.
+
+This module defines a :class:`Calculator` capable of evaluating arithmetic
+expressions composed of numbers, the operators ``+``, ``-``, ``*``, ``/``,
+``//``, ``%``, and ``**``, as well as parentheses and selected built-in
+functions. A small command-line interface is provided for convenience.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import operator
+import sys
+from typing import Callable, Dict, List, Optional, Union
+
+Number = Union[int, float]
+
+
+class Calculator:
+    """Evaluate arithmetic expressions in a controlled manner.
+
+    The implementation parses expressions using :mod:`ast` and evaluates only
+    a curated subset of Python's syntax tree nodes. This keeps evaluation
+    deterministic and avoids arbitrary code execution while still supporting a
+    handy set of arithmetic features.
+    """
+
+    _BINARY_OPERATORS: Dict[type, Callable[[Number, Number], Number]] = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+        ast.FloorDiv: operator.floordiv,
+        ast.Mod: operator.mod,
+        ast.Pow: operator.pow,
+    }
+
+    _UNARY_OPERATORS: Dict[type, Callable[[Number], Number]] = {
+        ast.UAdd: operator.pos,
+        ast.USub: operator.neg,
+    }
+
+    _ALLOWED_FUNCTIONS: Dict[str, Callable[..., Number]] = {
+        "abs": abs,
+        "round": round,
+    }
+
+    def evaluate(self, expression: str) -> Number:
+        """Evaluate *expression* and return the resulting number.
+
+        Args:
+            expression: The arithmetic expression to evaluate.
+
+        Returns:
+            The numeric result of the expression.
+
+        Raises:
+            ValueError: If the expression is empty or contains unsupported
+                syntax.
+            ZeroDivisionError: If a division by zero is attempted.
+        """
+
+        cleaned = expression.strip()
+        if not cleaned:
+            raise ValueError("Expression must not be empty.")
+
+        try:
+            parsed = ast.parse(cleaned, mode="eval")
+        except SyntaxError as exc:  # pragma: no cover - defensive guard
+            raise ValueError("Invalid expression.") from exc
+
+        return self._evaluate_node(parsed.body)
+
+    def _evaluate_node(self, node: ast.AST) -> Number:
+        if isinstance(node, ast.BinOp):
+            return self._evaluate_binop(node)
+        if isinstance(node, ast.UnaryOp):
+            return self._evaluate_unaryop(node)
+        if isinstance(node, ast.Call):
+            return self._evaluate_call(node)
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float)):
+                return node.value
+            raise ValueError(f"Unsupported constant: {node.value!r}")
+        if isinstance(node, ast.Num):  # pragma: no cover - Python <3.8
+            if isinstance(node.n, (int, float)):
+                return node.n
+            raise ValueError(f"Unsupported number: {node.n!r}")
+        if isinstance(node, ast.Expression):
+            return self._evaluate_node(node.body)
+
+        raise ValueError(f"Unsupported expression component: {ast.dump(node)}")
+
+    def _evaluate_binop(self, node: ast.BinOp) -> Number:
+        operator_type = type(node.op)
+        if operator_type not in self._BINARY_OPERATORS:
+            raise ValueError(f"Unsupported operator: {operator_type.__name__}")
+
+        left = self._evaluate_node(node.left)
+        right = self._evaluate_node(node.right)
+
+        if operator_type in {ast.Div, ast.FloorDiv, ast.Mod} and right == 0:
+            raise ZeroDivisionError("Division by zero is not allowed.")
+
+        operation = self._BINARY_OPERATORS[operator_type]
+        return operation(left, right)
+
+    def _evaluate_unaryop(self, node: ast.UnaryOp) -> Number:
+        operator_type = type(node.op)
+        if operator_type not in self._UNARY_OPERATORS:
+            raise ValueError(f"Unsupported unary operator: {operator_type.__name__}")
+
+        operand = self._evaluate_node(node.operand)
+        operation = self._UNARY_OPERATORS[operator_type]
+        return operation(operand)
+
+    def _evaluate_call(self, node: ast.Call) -> Number:
+        if not isinstance(node.func, ast.Name):
+            raise ValueError("Only direct function calls are supported.")
+
+        name = node.func.id
+        if name not in self._ALLOWED_FUNCTIONS:
+            raise ValueError(f"Function '{name}' is not allowed.")
+
+        function = self._ALLOWED_FUNCTIONS[name]
+        args = [self._evaluate_node(arg) for arg in node.args]
+        kwargs = {kw.arg: self._evaluate_node(kw.value) for kw in node.keywords}
+
+        try:
+            return function(*args, **kwargs)
+        except TypeError as exc:  # pragma: no cover - delegated error handling
+            raise ValueError(str(exc)) from exc
+
+
+def _emit_result(result: Number, decimals: Optional[int]) -> None:
+    if decimals is not None:
+        result = round(result, decimals)
+    print(result)
+
+
+def _run_repl(calculator: Calculator, decimals: Optional[int]) -> None:
+    print("Interaktivní režim. Ukončete příkazem 'exit'/'quit' nebo Ctrl-D.")
+    while True:
+        try:
+            expression = input(">>> ")
+        except EOFError:
+            print()
+            break
+
+        cleaned = expression.strip()
+        if not cleaned:
+            continue
+        if cleaned.lower() in {"exit", "quit"}:
+            break
+
+        try:
+            result = calculator.evaluate(cleaned)
+        except Exception as exc:  # pragma: no cover - reported to the user
+            print(f"Chyba: {exc}")
+            continue
+
+        _emit_result(result, decimals)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Run the calculator's command-line interface."""
+
+    parser = argparse.ArgumentParser(description="Evaluate a mathematical expression.")
+    parser.add_argument(
+        "expression",
+        nargs="?",
+        default=None,
+        help=(
+            "Expression to evaluate. Surround it with quotes to avoid shell interpretation. "
+            "Omit it or use --interactive to start the REPL."
+        ),
+    )
+    parser.add_argument(
+        "-d",
+        "--decimals",
+        type=int,
+        default=None,
+        help="Round the result to the specified number of decimal places.",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Start the calculator in interactive mode.",
+    )
+
+    args = parser.parse_args(argv)
+
+    calculator = Calculator()
+
+    if args.expression is None:
+        if args.interactive:
+            _run_repl(calculator, args.decimals)
+            return
+
+        if not sys.stdin.isatty():
+            streamed = sys.stdin.read().strip()
+            if not streamed:
+                return
+            _emit_result(calculator.evaluate(streamed), args.decimals)
+            return
+
+        _run_repl(calculator, args.decimals)
+        return
+
+    if args.interactive:
+        try:
+            result = calculator.evaluate(args.expression)
+        except Exception as exc:  # pragma: no cover - delegated to CLI feedback
+            print(f"Chyba: {exc}")
+        else:
+            _emit_result(result, args.decimals)
+        _run_repl(calculator, args.decimals)
+        return
+
+    result = calculator.evaluate(args.expression)
+    _emit_result(result, args.decimals)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+
+
+__all__ = ["Calculator", "main"]

--- a/calculator/__main__.py
+++ b/calculator/__main__.py
@@ -1,0 +1,6 @@
+"""Command-line entry point for the calculator package."""
+from . import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import io
+
+import pytest
+
+from calculator import Calculator, main
+
+
+@pytest.fixture
+def calculator() -> Calculator:
+    return Calculator()
+
+
+def test_basic_arithmetic(calculator: Calculator) -> None:
+    assert calculator.evaluate("2 + 3 * 4") == 14
+
+
+def test_parentheses_and_power(calculator: Calculator) -> None:
+    assert calculator.evaluate("(2 + 3) ** 2") == 25
+
+
+def test_unary_operations(calculator: Calculator) -> None:
+    assert calculator.evaluate("-5 + +2") == -3
+
+
+def test_division_by_zero(calculator: Calculator) -> None:
+    with pytest.raises(ZeroDivisionError):
+        calculator.evaluate("10 / 0")
+
+
+def test_abs_function(calculator: Calculator) -> None:
+    assert calculator.evaluate("abs(-7)") == 7
+
+
+def test_round_function(calculator: Calculator) -> None:
+    assert calculator.evaluate("round(10 / 3, 2)") == round(10 / 3, 2)
+
+
+def test_invalid_function(calculator: Calculator) -> None:
+    with pytest.raises(ValueError):
+        calculator.evaluate("pow(2, 3)")
+
+
+def test_invalid_expression(calculator: Calculator) -> None:
+    with pytest.raises(ValueError):
+        calculator.evaluate("")
+
+
+def test_cli_evaluates_expression(capsys) -> None:
+    main(["2 + 2"])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "4"
+
+
+def test_cli_reads_from_stdin(monkeypatch, capsys) -> None:
+    class FakeInput(io.StringIO):
+        def isatty(self) -> bool:  # pragma: no cover - simple helper
+            return False
+
+    fake_stdin = FakeInput("3 * 3")
+    monkeypatch.setattr("sys.stdin", fake_stdin)
+
+    main([])
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "9"
+
+
+def test_cli_interactive_mode(monkeypatch, capsys) -> None:
+    responses = iter(["2 + 3", "quit"])
+
+    def fake_input(prompt: str = "") -> str:
+        print(prompt, end="")
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    main(["--interactive"])
+
+    captured = capsys.readouterr()
+
+    assert "Interaktivní režim" in captured.out
+    assert "5" in captured.out.split()


### PR DESCRIPTION
## Summary
- allow the calculator CLI to run in an interactive session or read an expression from standard input when none is provided
- refactor the CLI implementation with reusable helpers and expose the calculator entry point via `__all__`
- document the new usage options and extend the test suite to cover CLI behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9571c40e48321ada530c01b46b484